### PR TITLE
Milestone4 + ServerUI

### DIFF
--- a/Milestone4/ClientUI.java
+++ b/Milestone4/ClientUI.java
@@ -1,0 +1,504 @@
+package client;
+
+import java.awt.BorderLayout;
+
+
+
+import java.awt.CardLayout;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.Font;
+import java.awt.FontMetrics;
+import java.awt.Toolkit;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.KeyEvent;
+import java.io.BufferedWriter;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.Writer;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.swing.AbstractAction;
+import javax.swing.BorderFactory;
+import javax.swing.BoxLayout;
+import javax.swing.JButton;
+import javax.swing.JEditorPane;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JMenu;
+import javax.swing.JMenuBar;
+import javax.swing.JMenuItem;
+import javax.swing.JPanel;
+import javax.swing.JScrollBar;
+import javax.swing.JScrollPane;
+import javax.swing.JTextArea;
+import javax.swing.JTextField;
+import javax.swing.KeyStroke;
+import javax.swing.ScrollPaneConstants;
+import javax.swing.Timer;
+
+public class ClientUI extends JFrame implements Event /*, ActionListener*/ {
+    /**
+     * 
+     */
+    private static final long serialVersionUID = 1L;
+    CardLayout card;
+    ClientUI self;
+    JPanel textArea;
+    JPanel userPanel;
+
+    List<User> users = new ArrayList<User>();
+    private final static Logger log = Logger.getLogger(ClientUI.class.getName());
+    Dimension windowSize = Toolkit.getDefaultToolkit().getScreenSize();
+    
+    String username;
+    RoomsPanel roomsPanel;
+    JMenuBar menu;
+    
+
+    public ClientUI(String title) {
+		setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+		menu = new JMenuBar();
+		JMenu roomsMenu = new JMenu("Actions");
+		JMenuItem roomsSearch = new JMenuItem("Rooms");
+		roomsSearch.addActionListener(new ActionListener() {
+		    @Override
+		    public void actionPerformed(ActionEvent e) {
+			goToPanel("rooms");
+		    }
+		});
+		roomsMenu.add(roomsSearch);
+		menu.add(roomsMenu);
+		windowSize.width *= .4;
+		windowSize.height *= .4;
+		setPreferredSize(windowSize);
+		setSize(windowSize);
+		setLocationRelativeTo(null);
+		self = this;
+		setTitle(title);
+		card = new CardLayout();
+		setLayout(card);
+		createConnectionScreen();
+		createUserInputScreen();
+		createPanelRoom();
+		createPanelUserList();
+		this.setJMenuBar(menu);
+		//createDrawingPanel();
+		createRoomsPanel();
+		showUI();
+    }
+
+    void createConnectionScreen() {
+		JPanel panel = new JPanel();
+		panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
+		JLabel hostLabel = new JLabel("Host:");
+		JTextField host = new JTextField("127.0.0.1");
+		panel.add(hostLabel);
+		panel.add(host);
+		JLabel portLabel = new JLabel("Port:");
+		JTextField port = new JTextField("3000");
+		panel.add(portLabel);
+		panel.add(port);
+		JButton button = new JButton("Next");
+		button.addActionListener(new ActionListener() {
+	
+		    @Override
+		    public void actionPerformed(ActionEvent e) {
+			String _host = host.getText();
+			String _port = port.getText();
+			if (_host.length() > 0 && _port.length() > 0) {
+			    try {
+				connect(_host, _port);
+				self.next();
+			    }
+			    catch (IOException e1) {
+				e1.printStackTrace();
+				// TODO handle error properly
+				log.log(Level.SEVERE, "Error connecting");
+			    }
+			}
+		    }
+	
+		});
+		host.getInputMap().put(KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, 0), "sendAction");
+		host.getActionMap().put("sendAction", new AbstractAction() {
+		    public void actionPerformed(ActionEvent actionEvent) {
+			button.doClick();
+		    }
+		});
+		panel.add(button);
+		this.add(panel, "login");
+    }
+
+    void createUserInputScreen() {
+		JPanel panel = new JPanel();
+		panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
+		JLabel userLabel = new JLabel("Username:");
+		JTextField username = new JTextField();
+		panel.add(userLabel);
+		panel.add(username);
+		JButton button = new JButton("Join");
+		ClientUI self = this;
+		button.addActionListener(new ActionListener() {
+	
+		    @Override
+		    public void actionPerformed(ActionEvent e) {
+			String name = username.getText();
+			if (name != null && name.length() > 0) {
+			    // need external ref since "this" context is the action event, not ClientUI
+			    self.username = name;
+			    // this order matters
+			    //createDrawingPanel();
+			    pack();
+			    self.setTitle(self.getTitle() + " - " + self.username);
+			    //game.setPlayerName(self.username);
+			    SocketClient.INSTANCE.setUsername(self.username);
+	
+			    self.next();
+			}
+		    }
+	
+		});
+		// TODO set focus later
+		username.getInputMap().put(KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, 0), "sendAction");
+		username.getActionMap().put("sendAction", new AbstractAction() {
+			public void actionPerformed(ActionEvent actionEvent) {
+			button.doClick();
+			}
+		});
+		panel.add(button);
+		this.add(panel, "details");
+    }
+
+    void createPanelRoom() {
+		JPanel panel = new JPanel();
+		panel.setLayout(new BorderLayout());
+	
+		textArea = new JPanel();
+		textArea.setLayout(new BoxLayout(textArea, BoxLayout.Y_AXIS));
+		textArea.setAlignmentY(Component.BOTTOM_ALIGNMENT);
+		JScrollPane scroll = new JScrollPane(textArea);
+		scroll.setHorizontalScrollBarPolicy(ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
+		scroll.setVerticalScrollBarPolicy(ScrollPaneConstants.VERTICAL_SCROLLBAR_AS_NEEDED);
+		Dimension d = new Dimension((int) (windowSize.width * .3), windowSize.height);
+		scroll.setPreferredSize(d);
+		scroll.setMinimumSize(d);
+		scroll.setMaximumSize(d);
+		panel.add(scroll, BorderLayout.CENTER);
+	
+		JPanel input = new JPanel();
+		input.setLayout(new BoxLayout(input, BoxLayout.X_AXIS));
+		JTextArea text = new JTextArea();
+		input.add(text);
+		JButton button = new JButton("Send");
+		text.getInputMap().put(KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, 0), "sendAction");
+		text.getActionMap().put("sendAction", new AbstractAction() {
+		    public void actionPerformed(ActionEvent actionEvent) {
+			button.doClick();
+		    }
+		});
+	
+		button.addActionListener(new ActionListener() {
+	
+		    @Override
+		    public void actionPerformed(ActionEvent e) {
+			if (text.getText().length() > 0) {
+			    SocketClient.INSTANCE.sendMessage(text.getText());
+			    text.setText("");
+			}
+		    }
+	
+		});
+		input.add(button);
+		
+		//export chat on button press
+		JButton export = new JButton("Export Chat");
+		export.addActionListener(new ActionListener() {
+	
+		    @Override
+		    public void actionPerformed(ActionEvent e) {
+			if (textArea.getComponents().length > 0) {
+			    exportCurrentChat();
+			}
+			
+		}});
+		
+		input.add(export);
+		panel.add(input, BorderLayout.SOUTH);
+		this.add(panel, "lobby");
+    }
+
+    void createPanelUserList() {
+		userPanel = new JPanel();
+		userPanel.setLayout(new BoxLayout(userPanel, BoxLayout.Y_AXIS));
+		userPanel.setAlignmentY(Component.TOP_ALIGNMENT);
+	
+		JScrollPane scroll = new JScrollPane(userPanel);
+		scroll.setHorizontalScrollBarPolicy(ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
+		scroll.setVerticalScrollBarPolicy(ScrollPaneConstants.VERTICAL_SCROLLBAR_AS_NEEDED);
+	
+		Dimension d = new Dimension((int) (windowSize.width * .2), windowSize.height);
+		scroll.setPreferredSize(d);
+		scroll.setMinimumSize(d);
+		scroll.setMaximumSize(d);
+
+	
+		textArea.getParent().getParent().getParent().add(scroll, BorderLayout.EAST);
+    }
+    
+    void createRoomsPanel() {
+    	roomsPanel = new RoomsPanel(this);
+    	this.add(roomsPanel, "rooms");
+    }
+
+    void addClient(String name) {
+		User u = new User(name, "%s");
+		Dimension p = new Dimension(userPanel.getSize().width, 35);
+		u.setPreferredSize(p);
+		u.setMinimumSize(p);
+		u.setMaximumSize(p);
+		userPanel.add(u);
+		users.add(u);
+		pack();
+	}
+
+    void removeClient(User client) {
+		userPanel.remove(client);
+		client.removeAll();
+		userPanel.revalidate();
+		userPanel.repaint();
+    }
+
+    /***
+     * Attempts to calculate the necessary dimensions for a potentially wrapped
+     * string of text. This isn't perfect and some extra whitespace above or below
+     * the text may occur
+     * 
+     * @param str
+     * @return
+     */
+    int calcHeightForText(String str) {
+		FontMetrics metrics = self.getGraphics().getFontMetrics(self.getFont());
+		int hgt = metrics.getHeight();
+		int adv = metrics.stringWidth(str);
+		final int PIXEL_PADDING = 6;
+		Dimension size = new Dimension(adv, hgt + PIXEL_PADDING);
+		final float PADDING_PERCENT = 1.1f;
+		// calculate modifier to line wrapping so we can display the wrapped message
+		int mult = (int) Math.floor(size.width / (textArea.getSize().width * PADDING_PERCENT));
+		mult++;
+		return size.height * mult;
+    }
+
+    void addMessage(String str) {
+		JEditorPane entry = new JEditorPane();
+		entry.setContentType("text/html");
+		entry.setEditable(false);
+		// entry.setLayout(null);
+		entry.setText(str);
+		Dimension d = new Dimension(textArea.getSize().width, calcHeightForText(str));
+		// attempt to lock all dimensions
+		entry.setMinimumSize(d);
+		entry.setPreferredSize(d);
+		entry.setMaximumSize(d);
+		textArea.add(entry);
+	
+		pack();
+		resizeTexts();
+		JScrollBar sb = ((JScrollPane) textArea.getParent().getParent()).getVerticalScrollBar();
+		sb.setValue(sb.getMaximum());
+    }
+    
+    void resizeTexts() {
+    	// attempts to fix sizing of messages when text area gets resized
+    	// sort of works so good enough for my example
+    	int areaWidth = textArea.getSize().width;
+    	int cc = textArea.getComponents().length;
+    	if (cc > 1) {
+    	    // if we have more than 1 text item
+    	    Component test = textArea.getComponent(cc - 2);
+    	    // check if the test width is different than our container
+    	    if (areaWidth != test.getWidth()) {
+    		// if so let's try to resize all the components to be the same width
+    		for (Component c : textArea.getComponents()) {
+    		    Dimension current = c.getSize();
+    		    Dimension updated = new Dimension(areaWidth, current.height);
+    		    c.setPreferredSize(updated);
+    		    c.setMinimumSize(updated);
+    		    c.setMaximumSize(updated);
+    		}
+    	    }
+    	}
+    }
+    
+    void next() {
+    	card.next(this.getContentPane());
+    }
+
+    void previous() {
+    	card.previous(this.getContentPane());
+    }
+    
+    void goToPanel(String panel) {
+    	switch (panel) {
+    	case "rooms":
+    	    // TODO get rooms
+    	    roomsPanel.removeAllRooms();
+    	    SocketClient.INSTANCE.sendGetRooms(null);
+    	    break;
+    	default:
+    	    break;
+    	}
+    	card.show(this.getContentPane(), panel);
+
+        }
+
+    void connect(String host, String port) throws IOException {
+	SocketClient.INSTANCE.registerCallbackListener(this);
+	SocketClient.INSTANCE.connectAndStart(host, port);
+    }
+
+    void showUI() {
+		pack();
+		Dimension lock = textArea.getSize();
+		textArea.setMaximumSize(lock);
+		lock = userPanel.getSize();
+		userPanel.setMaximumSize(lock);
+		setVisible(true);
+    }
+    
+    //expots current chat on button press to chat.txt
+    void exportCurrentChat() {
+	 	StringBuilder sb = new StringBuilder();
+	 	Component[] comps = textArea.getComponents();
+	 	for (Component c : comps) {
+	 	    JEditorPane j = (JEditorPane) c;
+	 	    if (j != null) {
+	 	    	// removes the HTML tags when writing to file
+	 	    	sb.append(j.getText().substring(44, j.getText().length() - 19) + System.lineSeparator());
+	 	    }
+	 	}
+	 	// todo save file
+	 	try {
+	 		FileWriter export = new FileWriter("chat.txt");
+	 		BufferedWriter bw = new BufferedWriter(export);
+			bw.write("" + sb.toString()); // convert StringBuilder to string
+			bw.close();
+			
+			addMessage("<i> chat history exported </i>");
+		} catch (IOException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+    }
+    
+    
+    @Override
+    public void onClientConnect(String clientName, String message) {
+		log.log(Level.INFO, String.format("%s: %s", clientName, message));
+		addClient(clientName);
+		if (message != null && !message.isBlank()) {
+		    self.addMessage(String.format("%s: %s", clientName, message));
+		}
+    }
+
+    @Override
+    public void onClientDisconnect(String clientName, String message) {
+		log.log(Level.INFO, String.format("%s: %s", clientName, message));
+		Iterator<User> iter = users.iterator();
+		while (iter.hasNext()) {
+		    User u = iter.next();
+		    if (u.getName() == clientName) {
+			removeClient(u);
+			iter.remove();
+			self.addMessage(String.format("%s: %s", clientName, message));
+			break;
+		    }
+	
+		}
+    }
+
+  
+	
+    @Override
+    public void onMessageReceive(String clientName, String message) {  
+    	log.log(Level.INFO, String.format("%s: %s", clientName, message));
+		self.addMessage(String.format("%s: %s", clientName, message));
+		Iterator<User> iter = users.iterator();
+		
+		// attempts to update client list on message receive
+		// whoever sent the most recent message has their name bolded
+		if (clientName != null && !clientName.isEmpty()) {
+			while (iter.hasNext()) {
+			    User u = iter.next();
+			    if (u.getName() != null && !u.getName().isEmpty()) {
+				    if(u.getName().equalsIgnoreCase(clientName)) {
+				    	u.setName(clientName, "<b>%s</b>");
+
+				    } 
+				 	else {
+				 		u.setName(u.getName(), "%s");
+
+				 	}
+				}
+			}
+		}
+	}
+
+
+    @Override
+    public void onChangeRoom() {
+		Iterator<User> iter = users.iterator();
+		while (iter.hasNext()) {
+		    User u = iter.next();
+		    removeClient(u);
+		    iter.remove();
+		}
+		goToPanel("lobby");
+    }
+
+    public static void main(String[] args) {
+	ClientUI ui = new ClientUI("My UI");
+	if (ui != null) {
+	    log.log(Level.FINE, "Started");
+	}
+    }
+    
+    @Override
+    public void onGetRoom(String roomName) {
+		// TODO Auto-generated method stub
+		if (roomsPanel != null) {
+		    roomsPanel.addRoom(roomName);
+		    pack();
+		}
+    }
+
+    // attempts to update client list on client mute
+ 	// whoever gets muted by clients gets their name crossed out
+	@Override
+	public void onIsMuted(String clientName, boolean isMuted) {
+		// TODO Auto-generated method stub
+		if (clientName != null && !clientName.isEmpty()) {
+			Iterator<User> iter = users.iterator();
+			while (iter.hasNext()) {
+			    User u = iter.next();
+			    if(u.getName().equalsIgnoreCase(clientName)) {
+			    	if (isMuted) {
+				    	u.setName(clientName, "<s>%s</s>");
+			    		//u.setName(clientName, "<font color=red>%s</font>");
+			 		}
+			 		else {
+			 		    u.setName(clientName, "%s");
+			 		}
+			    	break;
+			    }
+			}
+		}
+	}
+}

--- a/Milestone4/Event.java
+++ b/Milestone4/Event.java
@@ -1,0 +1,16 @@
+package client;
+
+public interface Event {
+    void onClientConnect(String clientName, String message);
+
+    void onClientDisconnect(String clientName, String message);
+
+    void onMessageReceive(String clientName, String message);
+
+    void onChangeRoom();
+    
+    void onGetRoom(String roomName);
+
+	void onIsMuted(String clientName, boolean isMuted);
+    
+}

--- a/Milestone4/Payload.java
+++ b/Milestone4/Payload.java
@@ -1,0 +1,65 @@
+package server;
+import java.io.Serializable;
+
+public class Payload implements Serializable {
+
+    /**
+     * baeldung.com/java-serial-version-uid
+     */
+    private static final long serialVersionUID = -6687715510484845706L;
+
+    private String clientName;
+
+    public void setClientName(String s) {
+	this.clientName = s;
+    }
+
+    public String getClientName() {
+	return clientName;
+    }
+
+    private String message;
+
+    public void setMessage(String s) {
+	this.message = s;
+    }
+
+    public String getMessage() {
+	return this.message;
+    }
+
+    private PayloadType payloadType;
+
+    public void setPayloadType(PayloadType pt) {
+	this.payloadType = pt;
+    }
+
+    public PayloadType getPayloadType() {
+	return this.payloadType;
+    }
+
+    private int number;
+
+    public void setNumber(int n) {
+	this.number = n;
+    }
+
+    public int getNumber() {
+	return this.number;
+    }
+    
+    private boolean flag;
+    
+    public void setFlag(boolean flag) {
+    	this.flag = flag;
+    }
+    public boolean getFlag() {
+    	return this.flag;
+    }
+    
+    @Override
+    public String toString() {
+	return String.format("Type[%s], Number[%s], Message[%s]", getPayloadType().toString(), getNumber(),
+		getMessage());
+    }
+}

--- a/Milestone4/PayloadType.java
+++ b/Milestone4/PayloadType.java
@@ -1,0 +1,5 @@
+package server;
+
+public enum PayloadType {
+    CONNECT, DISCONNECT, MESSAGE, CLEAR_PLAYERS, CREATE_ROOM, JOIN_ROOM, GET_ROOMS, MUTED
+}

--- a/Milestone4/Room.java
+++ b/Milestone4/Room.java
@@ -1,0 +1,556 @@
+package server;
+
+import java.util.ArrayList;
+
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Random;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+//import client.Player;
+
+public class Room implements AutoCloseable {
+    private static SocketServer server;// used to refer to accessible server functions
+    private String name;
+    private final static Logger log = Logger.getLogger(Room.class.getName());
+    
+    private List<ServerThread> clients = new ArrayList<ServerThread>();
+    
+    // Commands
+    private final static String COMMAND_TRIGGER = "/";
+    private final static String CREATE_ROOM = "createroom";
+    private final static String JOIN_ROOM = "joinroom";
+    private final static String FLIP = "flip";
+    private final static String ROLL = "roll";
+    private final static String MUTE = "mute";
+    private final static String UNMUTE = "unmute";
+    
+    public Room(String name) {
+	this.name = name;
+
+    }
+
+    public static void setServer(SocketServer server) {
+	Room.server = server;
+    }
+
+    public String getName() {
+	return name;
+    }
+
+    protected synchronized void addClient(ServerThread client) {
+	client.setCurrentRoom(this);
+	boolean exists = false;
+	// since we updated to a different List type, we'll need to loop through to find
+	// the client to check against
+	Iterator<ServerThread> iter = clients.iterator();
+	while (iter.hasNext()) {
+	    ServerThread c = iter.next();
+	    if (c == client) {
+		exists = true;
+		}
+		break;
+	}
+	if (exists) {
+	    log.log(Level.INFO, "Attempting to add a client that already exists");
+	}
+	else {
+	    clients.add(client);
+	    if (client.getClientName() != null) {
+		client.sendClearList();
+		sendConnectionStatus(client, true, "joined the room " + getName());
+		updateClientList(client);
+		// call serverUI addClient if serverUI is up
+		//if (SocketServer.run.equals("n") && getName().equals("Lobby")) {
+		//	server.addClient(client);
+		//}
+	    }
+	}
+    }
+
+    private void updateClientList(ServerThread client) {
+	Iterator<ServerThread> iter = clients.iterator();
+	while (iter.hasNext()) {
+	    ServerThread c = iter.next();
+	    if (c != client) {
+		client.sendConnectionStatus(c.getClientName(), true, null);
+	    }
+	}
+    }
+
+    protected synchronized void removeClient(ServerThread client) {
+    	Iterator<ServerThread> iter = clients.iterator();
+    	while (iter.hasNext()) {
+    	    ServerThread c = iter.next();
+    	    if (c == client) {
+	    		iter.remove();
+	    		log.log(Level.INFO, "Removed client " + c.getClientName() + " from " + getName());
+    	    }
+    	}
+	if (clients.size() > 0) {
+	    // sendMessage(client, "left the room");
+	    sendConnectionStatus(client, false, "left the room " + getName());
+		//if (SocketServer.run.equals("n") && getName().equals("Lobby")) {
+		//	server.removeClient(client);
+		//}
+	}
+	else {
+	    cleanupEmptyRoom();
+	}
+	// call serverUI removeClient if serverUI is up
+
+    }
+
+    private void cleanupEmptyRoom() {
+	// If name is null it's already been closed. And don't close the Lobby
+	if (name == null || name.equalsIgnoreCase(SocketServer.LOBBY)) {
+	    return;
+	}
+	try {
+	    log.log(Level.INFO, "Closing empty room: " + name);
+	    close();
+	}
+	catch (Exception e) {
+	    // TODO Auto-generated catch block
+	    e.printStackTrace();
+	}
+    }
+
+    protected void joinRoom(String room, ServerThread client) {
+	server.joinRoom(room, client);
+    }
+
+    protected void joinLobby(ServerThread client) {
+	server.joinLobby(client);
+	//client.loadMuteList();
+    }
+    
+    protected void createRoom(String room, ServerThread client) {
+	if (server.createNewRoom(room)) {
+	    sendMessage(client, "Created a new room");
+	    joinRoom(room, client);
+	}
+    }
+    
+    //flip and roll methods
+    Random flipRoll = new Random();
+    protected synchronized void roll(ServerThread client) {
+    	int result = flipRoll.nextInt(7);
+    	sendMessage(client, "<b><i><font color=purple> rolled a " + result + "</font></i></b>");
+    }
+     
+    protected synchronized void flip(ServerThread client) {
+    	int result = flipRoll.nextInt(2);
+    	String message;
+    	if(result == 0)
+    		message = " flipped heads";
+    	else 
+    		message = " flipped tails";
+    	sendMessage(client, "<b><i><font color=gray>" + message + "</font></i></b>");
+    }
+    
+    /***
+     * Helper function to process messages to trigger different functionality.
+     * 
+     * @param message The original message being sent
+     * @param client  The sender of the message (since they'll be the ones
+     *                triggering the actions)
+     */
+    
+    private boolean processCommands(String message, ServerThread client) {
+	boolean wasCommand = false;
+	try {
+		if (message.indexOf(COMMAND_TRIGGER) > -1) {
+		String[] comm = message.split(COMMAND_TRIGGER, 2);
+		
+		log.log(Level.INFO, message);
+		String part1 = comm[1];
+		String[] comm2 = part1.split(" ");
+		String command = comm2[0];
+		if (command != null) {
+		    command = command.toLowerCase();
+		}
+		
+		String roomName;
+		switch (command) {
+		case CREATE_ROOM:
+		    roomName = comm2[1];
+		    if (server.createNewRoom(roomName)) {
+			joinRoom(roomName, client);
+		    }
+		    wasCommand = true;
+		    break;
+		case JOIN_ROOM:
+		    roomName = comm2[1];
+		    joinRoom(roomName, client);
+		    wasCommand = true;
+		    break;
+	    //added "flip" and "roll" as potential cases
+		case FLIP:
+		    flip(client);
+		    wasCommand = true;
+		    break;
+	    case ROLL:
+		    roll(client);
+		    wasCommand = true;
+		    break;
+		  //added "mute" and "unmute" and potential cases
+	    case MUTE: 
+	    	String[] muted = comm2[1].split(", ");
+	    	List<String> muteList = new ArrayList<String>();
+	    	// can mute multiple clients separated by comma
+	    	for (String user : muted) {
+	    		if (!client.isMuted(user)) {
+		    		client.mute(user);
+		    		muteList.add(user);
+		    	}
+	    	}
+	    	sendPrivateMessage(client, " muted you", muteList);
+	   
+	    	wasCommand = true;
+	    	break;
+	    case UNMUTE:
+	    	String[] unmuted = comm2[1].split(", ");
+	    	List<String> unmuteList = new ArrayList<String>();
+	    	// can unmute multiple clients separated by comma
+	    	for (String user : unmuted) {
+	    		if (client.isMuted(user)) {
+	    			client.unmute(user);
+	    			unmuteList.add(user);
+		    	}
+	    	}
+	    	sendPrivateMessage(client, " unmuted you", unmuteList);
+	    	
+	    	wasCommand = true;
+	    	break;
+		}
+		} 
+		// private message functionality
+		// message will be sent to every user specified with an "@" 
+		//ex. "@user1 @user2 This message will be sent to user1 and user2."
+		else if (message.indexOf("@") > -1) {
+			String command = "";
+			String[] comm = message.split("@", 2);
+	
+			String part1 = comm[1];
+			String[] comm2 = part1.split(" @");
+			List<String> users = new ArrayList<String>();
+				// get list of intended users 
+			for (String user : comm2) {
+				if(!user.equals(comm2[comm2.length-1])) {
+					users.add(user.toLowerCase());
+				}
+				else {	// get message
+					String[] pm = user.split(" ", 2);
+					String last = pm[0];
+					users.add(last.toLowerCase());
+					command = pm[1];
+				}
+			}
+			List<String> sender = new ArrayList<String>();
+			sender.add(client.getClientName());
+			sendPrivateMessage(client, "<b> /pm </b> " + command, users);
+			sendPrivateMessage(client, "<b> to " + users.toString().substring(1, users.toString().length()-1) + ": </b> " + command, sender);
+	
+			wasCommand = true;
+		}
+		// change text functionality
+		else {
+			String command = message;
+			//BOLD
+			//makes sure there is at least one pair of "bold" symbols i.e *bold*
+			if (command.matches("(.*)\\*(.+)\\*(.*)")) {
+				int count = 0;
+				String changeText = "";
+			ArrayList<String> tags = new ArrayList<String>();
+			for (int i = 0; i < command.length(); i++) {
+				if (Character.toString(command.charAt(i)).equals("*")) {
+					count++;
+					if (count %2 != 0) {
+						tags.add("<b>");
+					}
+					else {
+						tags.add("</b>");
+					}
+					
+				}
+			}
+			String [] bold = command.split("\\*");
+			
+			//accounts for "***" as a potential text option
+			if (bold.length == 0) {
+				changeText += "<b>*</b>";
+						if (command.length() > 3)
+					changeText += command.substring(3);
+				
+			}
+			for (int i = 0; i < bold.length; i++) {
+				
+				// accounts for odd number of "*"
+				//  and also two "*" in a row
+				if (tags.size() == 1 && tags.get(tags.size()-1).contains("<b>") || (bold[i].equals("") && (bold[i+1].equals("")))) {
+					changeText += bold[i] + "*";
+					tags.remove(0);
+				}
+				// convet "**" pairs to "<b></b>"
+				else if (tags.size() > 1 || (tags.size() == 1 && tags.get(tags.size()-1).contains("</b>")) ){
+					changeText += bold[i] + tags.get(0);
+					tags.remove(0);
+				}
+				else changeText += bold[i];
+				}
+	    	wasCommand = true;
+	    	
+	    	// makes it so that conditions stack; 
+	    	// can have more than one type of function applied on the same line
+	    	if (changeText != "") {
+				command = changeText;
+			}
+	    }
+			// ITALICS
+			// same logic as bold
+			if (command.matches("(.*)_(.+)_(.*)")) {
+				int count = 0;
+				String changeText = "";
+				ArrayList<String> tags = new ArrayList<String>();
+				for (int i = 0; i < command.length(); i++) {
+					if (Character.toString(command.charAt(i)).equals("_")) {
+						count++;
+						if (count %2 != 0) {
+							tags.add("<i>");
+						}
+						else {
+							tags.add("</i>");
+						}
+					}
+				}
+				String [] italics = command.split("_");
+				if (italics.length == 0) {
+					changeText += "<i>_</i>";
+							if (command.length() > 3)
+						changeText += command.substring(3);
+					
+				}
+				for (int i = 0; i < italics.length; i++) {
+					if (tags.size() == 1 && tags.get(tags.size()-1).contains("<i>") || (italics[i].equals("") && (italics[i+1].equals("")))) {
+						changeText += italics[i] + "_";
+						tags.remove(0);
+					}
+					else if (tags.size() > 1 || (tags.size() == 1 && tags.get(tags.size()-1).contains("</i>")) ){ //if (i % 2 == 0) {
+						changeText += italics[i] + tags.get(0);
+						tags.remove(0);
+					}
+					else changeText += italics[i];
+					}
+		    	wasCommand = true;
+		    	if (changeText != "") {
+					command = changeText;
+				}
+	    }
+			// UNDERLINE
+			// same logic as bold
+			if (command.matches("(.*)~(.+)~(.*)")) {
+				int count = 0;
+				String changeText = "";
+				ArrayList<String> tags = new ArrayList<String>();
+				for (int i = 0; i < command.length(); i++) {
+					if (Character.toString(command.charAt(i)).equals("~")) {
+						count++;
+						if (count %2 != 0) {
+							tags.add("<u>");
+						}
+						else {
+							tags.add("</u>");
+						}
+						
+					}
+				}
+				String [] underline = command.split("~");
+				if (underline.length == 0) {
+					changeText += "<b>~</b>";
+							if (command.length() > 3)
+						changeText += command.substring(3);
+					
+				}			
+				for (int i = 0; i < underline.length; i++) {
+					if (tags.size() == 1 && tags.get(tags.size()-1).contains("<u>") || (underline[i].equals("") && (underline[i+1].equals("")))) {
+						changeText += underline[i] + "~";
+						tags.remove(0);
+					}
+					else if (tags.size() > 1 || (tags.size() == 1 && tags.get(tags.size()-1).contains("</i>")) ){ //if (i % 2 == 0) {
+						changeText += underline[i] + tags.get(0);
+						tags.remove(0);
+					}
+					else changeText += underline[i];
+					}
+		    	wasCommand = true;
+		    	if (changeText != "") {
+					command = changeText;
+				}
+	    }
+	
+		 // COLOR
+		 // change color by declaring a color between two pound signs
+			// e.x #red# this text would be red
+			// to change back to black/default type '##'
+			// color will stay black if declared color does not exist 
+				//e.x #null# this will stay black
+			if (command.matches("(.*)#(.+)#(.*)")) {
+				String changeText = "";
+				String colorString = "black";;
+				String [] color = command.split("#", -1);
+				System.out.println(Arrays.toString(color));
+				if (color.length == 0) {
+					changeText += command;	
+				}	
+					for (int i = 0; i < color.length; i++) {
+						
+						if (i % 2 != 0 && (!color[i].contains(" "))){
+							// accounts for odd number of #
+							if (i == color.length-1) {
+								changeText += "#" + color[i];
+							}
+							else { 
+								//if text is between two pound signs declare that as color variable
+								colorString = color[i];
+								if (colorString.equals("")) { colorString = "black"; }
+							}
+						}
+						// will not work if whitespace between pound signs i.e. # #
+						else if (i % 2 != 0 && (color[i].contains(" "))){
+							changeText += "#" + color[i] + "#";
+						}
+						// append message
+						else { 
+							changeText += "<font color="+colorString+">" + color[i] + "</font>";
+							colorString="black";
+						}
+					}
+				wasCommand = true;
+				if (changeText != "") {
+					command = changeText;
+				}
+				
+			}
+	   
+	    	if (wasCommand == true) {
+		    	sendMessage(client, command);
+		}
+
+		}
+	}
+	//catch (EOFException e) {
+		   // ... this is fine
+	//	}
+	catch (Exception e) {
+	    e.printStackTrace();
+	}
+	return wasCommand;
+    }
+
+    // TODO changed from string to ServerThread
+    protected void sendConnectionStatus(ServerThread client, boolean isConnect, String message) {
+	Iterator<ServerThread> iter = clients.iterator();
+	while (iter.hasNext()) {
+	    ServerThread c = iter.next();
+	    boolean messageSent = c.sendConnectionStatus(client.getClientName(), isConnect, message);
+	    if (!messageSent) {
+			iter.remove();
+			log.log(Level.INFO, "Removed client " + c.getId());
+	    }
+	}
+    }
+
+    /***
+     * Takes a sender and a message and broadcasts the message to all clients in
+     * this room. Client is mostly passed for command purposes but we can also use
+     * it to extract other client info.
+     * 
+     * @param sender  The client sending the message
+     * @param message The message to broadcast inside the room
+     */
+    
+    // if server ever needs to make an announcement to Room (not used)
+    protected void announcement(String message) {
+    	log.log(Level.INFO, getName() + ": Sending message to " + clients.size() + " clients");
+    	Iterator<ServerThread> iter = clients.iterator();
+    	while (iter.hasNext()) {
+    	    ServerThread client = iter.next();
+    	    	boolean messageSent = client.send("Announcement", message);
+    		    if (!messageSent) {
+    		    	iter.remove();
+    		    }
+    	    }
+    	}
+   
+    protected void sendMessage(ServerThread sender, String message) {
+	log.log(Level.INFO, getName() + ": Sending message to " + clients.size() + " clients");
+	if (processCommands(message, sender)) {
+	    // it was a command, don't broadcast
+	    return;
+	}
+	Iterator<ServerThread> iter = clients.iterator();
+	while (iter.hasNext()) {
+	    ServerThread client = iter.next();
+	    	// send message if sender not muted
+	    if (!client.isMuted(sender.getClientName())){
+	    	boolean messageSent = client.send(sender.getClientName(), message);
+		    if (!messageSent) {
+		    	iter.remove();
+		    }
+	    }
+	}
+    }
+    
+    //sends private message to specified array of clients
+    protected void sendPrivateMessage(ServerThread sender, String message, List<String> users) {
+	log.log(Level.INFO, getName() + ": Sending message to " + users.size() + " clients");
+	if (processCommands(message, sender)) {
+	    // it was a command, don't broadcast
+	    return;
+	}
+	Iterator<ServerThread> iter = clients.iterator();
+	while (iter.hasNext()) {
+	    ServerThread client = iter.next();
+	    	// send message if sender not muted
+	    if(users.contains(client.getClientName().toLowerCase())) {
+	    	if (!client.isMuted(sender.getClientName())){
+	    		boolean messageSent = client.send(sender.getClientName(), message);
+			    if (!messageSent) {
+			    	iter.remove();
+			    }
+	    	}
+	    }
+	}
+    }
+    
+    
+    public List<String> getRooms(String search) {
+    	return server.getRooms(search);
+        }
+    /***
+     * Will attempt to migrate any remaining clients to the Lobby room. Will then
+     * set references to null and should be eligible for garbage collection
+     */
+    @Override
+    public void close() throws Exception {
+	int clientCount = clients.size();
+	if (clientCount > 0) {
+	    log.log(Level.INFO, "Migrating " + clients.size() + " to Lobby");
+	    Iterator<ServerThread> iter = clients.iterator();
+	    Room lobby = server.getLobby();
+	    while (iter.hasNext()) {
+			ServerThread client = iter.next();
+			lobby.addClient(client);
+			iter.remove();
+	    }
+	    log.log(Level.INFO, "Done Migrating " + clients.size() + " to Lobby");
+	}
+	server.cleanupRoom(this);
+	name = null;
+	// should be eligible for garbage collection now
+    }
+
+}

--- a/Milestone4/Room.java
+++ b/Milestone4/Room.java
@@ -63,9 +63,9 @@ public class Room implements AutoCloseable {
 		sendConnectionStatus(client, true, "joined the room " + getName());
 		updateClientList(client);
 		// call serverUI addClient if serverUI is up
-		//if (SocketServer.run.equals("n") && getName().equals("Lobby")) {
-		//	server.addClient(client);
-		//}
+		if (SocketServer.run.equals("n") && getName().equals("Lobby")) {
+			server.addClient(client);
+		}
 	    }
 	}
     }
@@ -92,9 +92,9 @@ public class Room implements AutoCloseable {
 	if (clients.size() > 0) {
 	    // sendMessage(client, "left the room");
 	    sendConnectionStatus(client, false, "left the room " + getName());
-		//if (SocketServer.run.equals("n") && getName().equals("Lobby")) {
-		//	server.removeClient(client);
-		//}
+		if (SocketServer.run.equals("n") && getName().equals("Lobby")) {
+			server.removeClient(client);
+		}
 	}
 	else {
 	    cleanupEmptyRoom();

--- a/Milestone4/RoomListItem.java
+++ b/Milestone4/RoomListItem.java
@@ -1,0 +1,57 @@
+package client;
+
+ import java.awt.event.ActionEvent;
+ import java.awt.event.ActionListener;
+ import java.util.function.Consumer;
+
+ import javax.swing.BoxLayout;
+ import javax.swing.JButton;
+ import javax.swing.JPanel;
+ import javax.swing.JTextField;
+
+ public class RoomListItem extends JPanel implements AutoCloseable {
+     /**
+      * 
+      */
+     private static final long serialVersionUID = -8340982098822138336L;
+     private JTextField roomName;
+     private JButton joinButton;
+
+     /**
+      * We pass the room name, and a callback for when the room is selected
+      * 
+      * @param room   - Name of room to show on the UI
+      * @param onJoin - Callback to trigger when button is clicked
+      */
+     public RoomListItem(String room, Consumer<String> onJoin) {
+ 	// TODO see below links regarding Consumer
+ 	// https://medium.com/swlh/understanding-java-8s-consumer-supplier-predicate-and-function-c1889b9423d
+ 	// https://mkyong.com/java8/java-8-consumer-examples/
+ 	this.setLayout(new BoxLayout(this, BoxLayout.X_AXIS));
+ 	roomName = new JTextField(room);
+ 	roomName.setEditable(false);
+ 	joinButton = new JButton("Join");
+ 	joinButton.addActionListener(new ActionListener() {
+
+ 	    @Override
+ 	    public void actionPerformed(ActionEvent e) {
+ 		// invokes the callback
+ 		onJoin.accept(roomName.getText());
+ 	    }
+ 	});
+ 	this.add(roomName);
+ 	this.add(joinButton);
+     }
+
+     @Override
+     public void close() {
+ 	for (ActionListener al : joinButton.getActionListeners()) {
+ 	    joinButton.removeActionListener(al);
+ 	}
+ 	this.removeAll();
+     }
+
+     public String getRoomName() {
+ 	return roomName.getText();
+     }
+ }

--- a/Milestone4/RoomsPanel.java
+++ b/Milestone4/RoomsPanel.java
@@ -1,0 +1,167 @@
+package client;
+
+import java.awt.BorderLayout;
+
+import java.awt.Dimension;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.KeyEvent;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import javax.swing.AbstractAction;
+import javax.swing.BoxLayout;
+import javax.swing.JButton;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTabbedPane;
+import javax.swing.JTextField;
+import javax.swing.KeyStroke;
+import javax.swing.ScrollPaneConstants;
+
+public class RoomsPanel extends JPanel {
+
+    /**
+     * 
+     */
+    private static final long serialVersionUID = 1L;
+    List<RoomListItem> rooms = new ArrayList<RoomListItem>();
+    JPanel container;
+    JFrame parent;
+
+    public RoomsPanel(JFrame frame) {
+	parent = frame;
+	container = new JPanel();
+	JScrollPane scroll = new JScrollPane(container);
+	container.setLayout(new BoxLayout(container, BoxLayout.Y_AXIS));
+	container.setAlignmentY(TOP_ALIGNMENT);
+	scroll.setHorizontalScrollBarPolicy(ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
+	scroll.setVerticalScrollBarPolicy(ScrollPaneConstants.VERTICAL_SCROLLBAR_AS_NEEDED);
+	this.setLayout(new BorderLayout());
+
+	
+	// create a tabbled panel that'll let us change between search and create
+	JTabbedPane tabbedPane = new JTabbedPane();
+	// create the search section (label and input)
+	JLabel searchLabel = new JLabel("Search");
+	JTextField search = new JTextField();
+	// let us submit the search via the enter key
+	search.getInputMap().put(KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, 0), "sendAction");
+	search.getActionMap().put("sendAction", new AbstractAction() {
+	    /**
+		 * 
+		 */
+		private static final long serialVersionUID = 1L;
+
+		public void actionPerformed(ActionEvent actionEvent) {
+		String query = search.getText();
+		// only search if the string isn't empty
+		if (!query.isEmpty()) {
+		    removeAllRooms();
+		    SocketClient.INSTANCE.sendGetRooms(query);
+		}
+	    }
+	});
+	Dimension d = new Dimension(this.getSize().width, 40);
+	search.setPreferredSize(d);
+	search.setMaximumSize(d);
+	// create the "create" label and input
+	JLabel createLabel = new JLabel("Create");
+	JTextField create = new JTextField();
+	// trigger it on enter key
+	create.getInputMap().put(KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, 0), "sendAction");
+	create.getActionMap().put("sendAction", new AbstractAction() {
+	    /**
+		 * 
+		 */
+		private static final long serialVersionUID = 1L;
+
+		public void actionPerformed(ActionEvent actionEvent) {
+		String query = create.getText();
+		// send the request only if a value was entered
+		if (!query.isEmpty()) {
+		    SocketClient.INSTANCE.sendCreateRoom(query);
+		}
+	    }
+	});
+
+	JButton back = new JButton("Go Back");
+	back.setPreferredSize(d);
+	back.setMaximumSize(d);
+	back.setSize(d);
+
+	back.addActionListener(new ActionListener() {
+
+	    @Override
+	    public void actionPerformed(ActionEvent e) {
+		((ClientUI) parent).previous();
+	    }
+	});
+	JPanel searchPanel = new JPanel();
+	searchPanel.setLayout(new BorderLayout());
+	searchPanel.add(searchLabel, BorderLayout.NORTH);
+	searchPanel.add(search, BorderLayout.CENTER);
+	tabbedPane.add(searchPanel, "Search");
+	JPanel createPanel = new JPanel();
+	createPanel.setLayout(new BorderLayout());
+	createPanel.add(createLabel, BorderLayout.NORTH);
+	createPanel.add(create, BorderLayout.CENTER);
+	tabbedPane.add(createPanel, "Create");
+	// this.add(searchPanel, BorderLayout.NORTH);
+	this.add(tabbedPane, BorderLayout.NORTH);
+	this.add(back, BorderLayout.SOUTH);
+	this.add(container, BorderLayout.CENTER);
+
+    }
+
+    public void addRoom(String room) {
+	if (room != null) {
+	    System.out.println("Adding: " + room);
+	    RoomListItem r = new RoomListItem(room, (String roomName) -> handleSelection(roomName));
+	    Dimension size = new Dimension(this.getSize().width, 40);
+	    r.setPreferredSize(size);
+	    r.setMaximumSize(size);
+	    r.setMinimumSize(size);
+	    container.add(r);
+	    rooms.add(r);
+	}
+    }
+
+    public void removeRoom(String room) {
+	Iterator<RoomListItem> iter = rooms.iterator();
+	while (iter.hasNext()) {
+	    RoomListItem r = iter.next();
+	    if (r.getRoomName().equalsIgnoreCase(room)) {
+		r.close();
+		r.removeAll();
+		container.remove(r);
+		iter.remove();
+		break;
+	    }
+	}
+	parent.invalidate();
+	parent.repaint();
+    }
+
+    public void removeAllRooms() {
+	System.out.println("Clearing rooms");
+	Iterator<RoomListItem> iter = rooms.iterator();
+	while (iter.hasNext()) {
+	    RoomListItem r = iter.next();
+	    System.out.println("Removing " + r.getRoomName());
+	    container.remove(r);
+	    r.close();
+	    iter.remove();
+	}
+	parent.invalidate();
+	parent.repaint();
+    }
+
+    public void handleSelection(String room) {
+	SocketClient.INSTANCE.sendJoinRoom(room);
+    }
+
+}

--- a/Milestone4/ServerThread.java
+++ b/Milestone4/ServerThread.java
@@ -1,0 +1,348 @@
+package server;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileWriter;
+import java.io.IOException;
+ import java.io.ObjectInputStream;
+ import java.io.ObjectOutputStream;
+ import java.net.Socket;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+ import java.util.List;
+import java.util.Scanner;
+import java.util.logging.Level;
+ import java.util.logging.Logger;
+
+ public class ServerThread extends Thread {
+	 
+     private Socket client;
+     private ObjectInputStream in;// from client
+     private ObjectOutputStream out;// to client
+     boolean isRunning = false;
+     private Room currentRoom;// what room we are in, should be lobby by default
+     private String clientName;
+     private final static Logger log = Logger.getLogger(ServerThread.class.getName());
+
+     List<String> mutedClients = new ArrayList<String>();
+     
+     public List<String> getMutedClients() {
+    	 return this.mutedClients;
+     }
+     
+     //mutes client on call
+     public void mute(String name) {
+     	name = name.trim().toLowerCase();
+     	if (!isMuted(name)) {
+     		mutedClients.add(name);
+     		saveMuteList();
+     		syncIsMuted(name, true);
+     	}
+     }
+     
+     //unmutes clients on call
+  	public void unmute(String name) {
+  		name = name.trim().toLowerCase();
+     	if (isMuted(name)) {
+     		System.out.println("ok");
+     		mutedClients.remove(name);
+     		System.out.println("yessir");
+     		saveMuteList();
+     		syncIsMuted(name, false);
+     	}
+  
+     }
+  	
+  	//checks to see if client is muted
+    public boolean isMuted(String name) {
+     	name = name.trim().toLowerCase();
+     	return mutedClients.contains(name);
+   	} 
+     
+    // overwrites client's mutedClients list to a file
+    void saveMuteList() {
+    	 String data = clientName + ": " + String.join(", ", mutedClients);
+    	 try {
+ 	 		FileWriter export = new FileWriter(clientName + ".txt");
+ 	 		BufferedWriter bw = new BufferedWriter(export);
+ 			bw.write("" + data); // convert StringBuilder to string
+ 			bw.close();
+ 		} catch (IOException e) {
+ 			// TODO Auto-generated catch block
+ 			e.printStackTrace();
+ 		}
+    }
+
+    // loads client's mutedClients list on reconnect
+   void loadMuteList() {
+	   	 File file = new File(clientName + ".txt");
+	   	 if (file.exists()) {
+		   	 try (Scanner reader = new Scanner(file)) {
+		   		String dataFromFile = "";
+		   		while (reader.hasNextLine()) {
+			   		 String text = reader.nextLine();
+			   		 dataFromFile += text;
+		   		}
+		   		dataFromFile = dataFromFile.substring(dataFromFile.indexOf(" ")+1);;
+		   		if (!dataFromFile.strip().equals("") && !dataFromFile.isEmpty()) {
+		   			List<String> getClients = Arrays.asList(dataFromFile.split(", "));
+		   	    	for (String client : getClients) {
+		   	    	    mute(client);
+		   	    	    System.out.println("sync");
+		   	    	}
+		   		}
+		   	 }
+		   	catch (FileNotFoundException e) {
+				e.printStackTrace();
+			} catch (Exception e2) {
+				e2.printStackTrace();
+			}
+	   	 }
+	   	 System.out.println(mutedClients.toString());
+    }
+	   	 
+   // sends client mute or unmute to clientside through payload
+   	protected boolean syncIsMuted(String clientName, boolean isMuted) {
+		Payload p = new Payload();
+		p.setPayloadType(PayloadType.MUTED);
+		p.setClientName(clientName);
+		p.setFlag(isMuted);
+		return sendPayload(p);
+    }
+     
+    public String getClientName() {
+ 	return clientName;
+     }
+
+    protected synchronized Room getCurrentRoom() {
+ 	return currentRoom;
+     }
+
+    protected synchronized void setCurrentRoom(Room room) {
+ 	if (room != null) {
+ 	    currentRoom = room;
+ 	}
+ 	else {
+ 	    log.log(Level.INFO, "Passed in room was null, this shouldn't happen");
+ 	}
+     }
+
+    public ServerThread(Socket myClient, Room room) throws IOException {
+	 	this.client = myClient;
+	 	this.currentRoom = room;
+	 	out = new ObjectOutputStream(client.getOutputStream());
+	 	in = new ObjectInputStream(client.getInputStream());
+    }
+    
+     /***
+      * Sends the message to the client represented by this ServerThread
+      * 
+      * @param message
+      * @return
+      */
+     @Deprecated
+    protected boolean send(String message) {
+ 	// added a boolean so we can see if the send was successful
+ 	try {
+ 	    out.writeObject(message);
+ 	    return true;
+ 	}
+ 	catch (IOException e) {
+ 	    log.log(Level.INFO, "Error sending message to client (most likely disconnected)");
+ 	    e.printStackTrace();
+ 	    cleanup();
+ 	    return false;
+ 	}
+    }
+
+     /***
+      * Replacement for send(message) that takes the client name and message and
+      * converts it into a payload
+      * 
+      * @param clientName
+      * @param message
+      * @return
+      */
+    protected boolean send(String clientName, String message) {
+ 	Payload payload = new Payload();
+ 	payload.setPayloadType(PayloadType.MESSAGE);
+ 	payload.setClientName(clientName);
+ 	payload.setMessage(message);
+
+ 	return sendPayload(payload);
+    }
+
+     protected boolean sendConnectionStatus(String clientName, boolean isConnect, String message) {
+ 	Payload payload = new Payload();
+ 	if (isConnect) {
+ 	    payload.setPayloadType(PayloadType.CONNECT);
+ 	    payload.setMessage(message);
+ 	}
+ 	else {
+ 	    payload.setPayloadType(PayloadType.DISCONNECT);
+ 	    payload.setMessage(message);
+ 	}
+ 	payload.setClientName(clientName);
+ 	return sendPayload(payload);
+     }
+
+    protected boolean sendClearList() {
+ 	Payload payload = new Payload();
+ 	payload.setPayloadType(PayloadType.CLEAR_PLAYERS);
+ 	return sendPayload(payload);
+     }
+
+    protected boolean sendRoom(String room) {
+ 	Payload payload = new Payload();
+ 	// using same payload type as a response trigger
+ 	payload.setPayloadType(PayloadType.GET_ROOMS);
+ 	payload.setMessage(room);
+ 	return sendPayload(payload);
+     }
+
+    private boolean sendPayload(Payload p) {
+ 	try {
+ 	    out.writeObject(p);
+ 	    return true;
+ 	}
+ 	catch (IOException e) {
+ 	    log.log(Level.INFO, "Error sending message to client (most likely disconnected)");
+ 	    e.printStackTrace();
+ 	    cleanup();
+ 	    return false;
+ 	}
+    }
+
+     /***
+      * Process payloads we receive from our client
+      * 
+      * @param p
+      */
+    private void processPayload(Payload p) {
+ 	switch (p.getPayloadType()) {
+ 	case CONNECT:
+ 	    // here we'll fetch a clientName from our client
+ 	    String n = p.getClientName();
+ 	    if (n != null) {
+ 		clientName = n;
+ 		log.log(Level.INFO, "Set our name to " + clientName);
+ 		if (currentRoom != null) {
+ 		    currentRoom.joinLobby(this);
+ 		}
+ 	    }
+ 	    break;
+ 	case DISCONNECT:
+ 	    isRunning = false;// this will break the while loop in run() and clean everything up
+ 	    break;
+ 	case MESSAGE:
+ 	    currentRoom.sendMessage(this, p.getMessage());
+ 	    break;
+ 	case CLEAR_PLAYERS:
+ 	    // we currently don't need to do anything since the UI/Client won't be sending
+ 	    // this
+ 	    break;
+ 	case GET_ROOMS:
+ 	    // far from efficient but it works for example sake
+ 	    List<String> roomNames = currentRoom.getRooms(p.getMessage());
+ 	    Iterator<String> iter = roomNames.iterator();
+ 	    while (iter.hasNext()) {
+ 		String room = iter.next();
+ 		if (room != null && !room.equalsIgnoreCase(currentRoom.getName())) {
+ 		    if (!sendRoom(room)) {
+ 			// if an error occurs stop spamming
+ 			break;
+ 		    }
+ 		}
+ 	    }
+ 	    break;
+ 	case CREATE_ROOM:
+ 	    currentRoom.createRoom(p.getMessage(), this);
+ 	    break;
+ 	case JOIN_ROOM:
+ 	    currentRoom.joinRoom(p.getMessage(), this);
+ 	    break;
+ 	default:
+ 	    log.log(Level.INFO, "Unhandled payload on server: " + p);
+ 	    break;
+ 	}
+    }
+
+     @Override
+    public void run() {
+ 	try {
+ 	    isRunning = true;
+ 	    Payload fromClient;
+ 	    while (isRunning && // flag to let us easily control the loop
+ 		    !client.isClosed() // breaks the loop if our connection closes
+ 		    && (fromClient = (Payload) in.readObject()) != null // reads an object from inputStream (null would
+ 									// likely mean a disconnect)
+ 	    ) {
+ 		System.out.println("Received from client: " + fromClient);
+ 		processPayload(fromClient);
+ 	    } // close while loop
+ 	}
+ 	catch (Exception e) {
+ 	    // happens when client disconnects
+ 	    e.printStackTrace();
+ 	    log.log(Level.INFO, "Client Disconnected");
+ 	}
+ 	finally {
+ 	    isRunning = false;
+ 	    log.log(Level.INFO, "Cleaning up connection for ServerThread");
+ 	    cleanup();
+ 	}
+     }
+
+     private void cleanup() {
+ 	if (currentRoom != null) {
+ 	    log.log(Level.INFO, getName() + " removing self from room " + currentRoom.getName());
+ 	    currentRoom.removeClient(this);
+ 	}
+ 	if (in != null) {
+ 	    try {
+ 		in.close();
+ 	    }
+ 	    catch (IOException e) {
+ 		log.log(Level.INFO, "Input already closed");
+ 	    }
+ 	}
+ 	if (out != null) {
+ 	    try {
+ 		out.close();
+ 	    }
+ 	    catch (IOException e) {
+ 		log.log(Level.INFO, "Client already closed");
+ 	    }
+ 	}
+ 	if (client != null && !client.isClosed()) {
+ 	    try {
+ 		client.shutdownInput();
+ 	    }
+ 	    catch (IOException e) {
+ 		log.log(Level.INFO, "Socket/Input already closed");
+ 	    }
+ 	    try {
+ 		client.shutdownOutput();
+ 	    }
+ 	    catch (IOException e) {
+ 		log.log(Level.INFO, "Socket/Output already closed");
+ 	    }
+ 	    try {
+ 		client.close();
+ 	    }
+ 	    catch (IOException e) {
+ 		log.log(Level.INFO, "Client already closed");
+ 	    }
+ 	}
+    }
+     
+     // called when serverUI disconnects client
+     public void disconnect() {
+    	 send("Announcement", " server disconnected you.");
+    	 cleanup();
+    	 isRunning = false;
+     }
+    
+ }

--- a/Milestone4/SocketClient.java
+++ b/Milestone4/SocketClient.java
@@ -1,0 +1,309 @@
+package client;
+
+import java.io.IOException;
+
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.net.Socket;
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import server.Payload;
+import server.PayloadType;
+
+public enum SocketClient {
+    INSTANCE; // see https://dzone.com/articles/java-singletons-using-enum "Making Singletons
+	      // with Enum"
+
+    private static Socket server;
+    private static Thread fromServerThread;
+    private static Thread clientThread;
+    private static String clientName;
+    private static ObjectOutputStream out;
+    private final static Logger log = Logger.getLogger(SocketClient.class.getName());
+    private static List<Event> events = new ArrayList<Event>();// change from event to list<event>
+
+    private Payload buildMessage(String message) {
+	Payload payload = new Payload();
+	payload.setPayloadType(PayloadType.MESSAGE);
+	payload.setClientName(clientName);
+	payload.setMessage(message);
+	return payload;
+    }
+
+    private Payload buildConnectionStatus(String name, boolean isConnect) {
+	Payload payload = new Payload();
+	if (isConnect) {
+	    payload.setPayloadType(PayloadType.CONNECT);
+	}
+	else {
+	    payload.setPayloadType(PayloadType.DISCONNECT);
+	}
+	payload.setClientName(name);
+	return payload;
+    }
+
+    private void sendPayload(Payload p) {
+	try {
+	    System.out.println("Sending: " + p);
+	    out.writeObject(p);
+	}
+	catch (IOException e) {
+	    // TODO Auto-generated catch block
+	    e.printStackTrace();
+	}
+    }
+
+    private void listenForServerMessage(ObjectInputStream in) {
+	if (fromServerThread != null) {
+	    log.log(Level.INFO, "Server Listener is likely already running");
+	    return;
+	}
+	// Thread to listen for responses from server so it doesn't block main thread
+	fromServerThread = new Thread() {
+	    @Override
+	    public void run() {
+		try {
+		    Payload fromServer;
+		    // while we're connected, listen for Payloads from server
+		    while (!server.isClosed() && (fromServer = (Payload) in.readObject()) != null) {
+			System.out.println("Received from SERVER: " + fromServer);
+			processPayload(fromServer);
+		    }
+		}
+		catch (Exception e) {
+		    if (!server.isClosed()) {
+			e.printStackTrace();
+			log.log(Level.INFO, "Server closed connection");
+		    }
+		    else {
+			log.log(Level.INFO, "Connection closed");
+		    }
+		}
+		finally {
+		    close();
+		    log.log(Level.INFO, "Stopped listening to server input");
+		}
+	    }
+	};
+	fromServerThread.start();// start the thread
+    }
+
+    private void sendOnClientConnect(String name, String message) {
+	Iterator<Event> iter = events.iterator();
+	while (iter.hasNext()) {
+	    Event e = iter.next();
+	    if (e != null) {
+		e.onClientConnect(name, message);
+	    }
+	}
+    }
+
+    private void sendOnClientDisconnect(String name, String message) {
+	Iterator<Event> iter = events.iterator();
+	while (iter.hasNext()) {
+	    Event e = iter.next();
+	    if (e != null) {
+		e.onClientDisconnect(name, message);
+	    }
+	}
+    }
+
+    private void sendOnMessage(String name, String message) {
+	Iterator<Event> iter = events.iterator();
+	while (iter.hasNext()) {
+	    Event e = iter.next();
+	    if (e != null) {
+		e.onMessageReceive(name, message);
+	    }
+	}
+    }
+
+    private void sendOnChangeRoom() {
+	Iterator<Event> iter = events.iterator();
+	while (iter.hasNext()) {
+	    Event e = iter.next();
+	    if (e != null) {
+		e.onChangeRoom();
+	    }
+	}
+    }
+
+    private void sendRoom(String roomName) {
+	Iterator<Event> iter = events.iterator();
+	while (iter.hasNext()) {
+	    Event e = iter.next();
+	    if (e != null) {
+		e.onGetRoom(roomName);
+	    }
+	}
+    }
+    
+    // receives MUTED payload from server and triggers onIsMuted in clientUI class
+    private void triggerIsMuted(String clientName, boolean isMuted) {
+	Iterator<Event> iter = events.iterator();
+	while (iter.hasNext()) {
+	    Event e = iter.next();
+	    if (e != null) {
+		e.onIsMuted(clientName, isMuted);
+	    }
+	}
+    }
+    /***
+     * Determine any special logic for different PayloadTypes
+     * 
+     * @param p
+     */
+    private void processPayload(Payload p) {
+
+	switch (p.getPayloadType()) {
+	case CONNECT:
+	    sendOnClientConnect(p.getClientName(), p.getMessage());
+	    break;
+	case DISCONNECT:
+	    sendOnClientDisconnect(p.getClientName(), p.getMessage());
+	    break;
+	case MESSAGE:
+	    sendOnMessage(p.getClientName(), p.getMessage());
+	    break;
+	case CLEAR_PLAYERS:
+	    sendOnChangeRoom();
+	    break;
+	case GET_ROOMS:
+	    // reply from ServerThread
+	    sendRoom(p.getMessage());
+	    break;
+	case MUTED:
+		triggerIsMuted(p.getClientName(), p.getFlag());
+		break;
+	default:
+ 	    log.log(Level.WARNING, "unhandled payload on client" + p);
+ 	    break;
+	}
+    }
+
+    // TODO Start public methods here
+
+    public void registerCallbackListener(Event e) {
+	events.add(e);
+	log.log(Level.INFO, "Attached listener");
+    }
+
+    public void removeCallbackListener(Event e) {
+	events.remove(e);
+    }
+
+    public boolean connectAndStart(String address, String port) throws IOException {
+	if (connect(address, port)) {
+	    return start();
+	}
+	return false;
+    }
+
+    public boolean connect(String address, String port) {
+	try {
+	    server = new Socket(address, Integer.parseInt(port));
+	    log.log(Level.INFO, "Client connected");
+	    return true;
+	}
+	catch (UnknownHostException e) {
+	    e.printStackTrace();
+	}
+	catch (IOException e) {
+	    e.printStackTrace();
+	}
+	return false;
+    }
+
+    public void setUsername(String username) {
+    	clientName = username;
+    	sendPayload(buildConnectionStatus(clientName, true));
+    }
+
+    public void sendMessage(String message) {
+    	sendPayload(buildMessage(message));
+    }
+
+    public void sendCreateRoom(String room) {
+		Payload p = new Payload();
+		p.setPayloadType(PayloadType.CREATE_ROOM);
+		p.setMessage(room);
+		sendPayload(p);
+    }
+
+    public void sendJoinRoom(String room) {
+		Payload p = new Payload();
+		p.setPayloadType(PayloadType.JOIN_ROOM);
+		p.setMessage(room);
+		sendPayload(p);
+    }
+
+    public void sendGetRooms(String query) {
+		Payload p = new Payload();
+		p.setPayloadType(PayloadType.GET_ROOMS);
+		p.setMessage(query);
+		sendPayload(p);
+    }
+    
+    public boolean start() throws IOException {
+		if (server == null) {
+		    log.log(Level.WARNING, "Server is null");
+		    return false;
+		}
+		if (clientThread != null && clientThread.isAlive()) {
+		    log.log(Level.SEVERE, "Client thread is already active");
+		    return false;
+		}
+		if (clientThread != null) {
+		    clientThread.interrupt();
+		    clientThread = null;
+		}
+		log.log(Level.INFO, "Client Started");
+		clientThread = new Thread() {
+		    @Override
+		    public void run() {
+	
+			// listen to console, server in, and write to server out
+			try (ObjectOutputStream out = new ObjectOutputStream(server.getOutputStream());
+				ObjectInputStream in = new ObjectInputStream(server.getInputStream());) {
+			    SocketClient.out = out;
+	
+			    // starts new thread
+			    listenForServerMessage(in);
+	
+			    // Keep main thread alive until the socket is closed
+			    // initialize/do everything before this line
+			    // (Without this line the program would stop after the first message
+			    while (!server.isClosed()) {
+				Thread.sleep(50);
+			    }
+			    log.log(Level.INFO, "Client Thread stopping");
+			}
+			catch (Exception e) {
+			    e.printStackTrace();
+			}
+			finally {
+			    close();
+			}
+		    }
+		};
+		clientThread.start();
+		return true;
+    }
+
+    public void close() {
+		if (server != null && !server.isClosed()) {
+		    try {
+			server.close();
+			log.log(Level.INFO, "Closed Socket");
+		    }
+		    catch (IOException e) {
+			e.printStackTrace();
+		    }
+		}
+    }
+}

--- a/Milestone4/SocketServer.java
+++ b/Milestone4/SocketServer.java
@@ -1,0 +1,327 @@
+package server;
+
+ import java.awt.BorderLayout;
+
+import java.awt.CardLayout;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.FontMetrics;
+import java.awt.Toolkit;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.lang.management.ManagementFactory;
+import java.lang.management.RuntimeMXBean;
+import java.net.ServerSocket;
+ import java.net.Socket;
+ import java.util.ArrayList;
+ import java.util.Iterator;
+ import java.util.List;
+import java.util.Scanner;
+import java.util.logging.Level;
+ import java.util.logging.Logger;
+ import java.io.IOException;
+
+ 
+import javax.swing.BoxLayout;
+import javax.swing.JButton;
+import javax.swing.JEditorPane;
+import javax.swing.JFrame;
+
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.ScrollPaneConstants; 
+
+ public class SocketServer extends JFrame{
+     /**
+	 * 
+	 */
+	private static final long serialVersionUID = 1L;
+
+	int port = 3000;
+     
+     CardLayout card;
+     JPanel textArea;
+     JPanel userPanel;
+     
+     Dimension windowSize = Toolkit.getDefaultToolkit().getScreenSize();
+     
+     String username;
+     
+     List<JPanel> userArray = new ArrayList<JPanel>();
+     private List<Client> clients = new ArrayList<Client>();
+     
+     public static boolean isRunning = false;
+     List<Room> rooms = new ArrayList<Room>();
+     private Room lobby;// here for convenience
+     private List<Room> isolatedPrelobbies = new ArrayList<Room>();
+     private final static String PRELOBBY = "PreLobby";
+     protected final static String LOBBY = "Lobby";
+     private final static Logger log = Logger.getLogger(SocketServer.class.getName());
+     
+     public static String run;
+     
+     void start(int port, String headless) {
+ 	this.port = port;
+ 	log.log(Level.INFO, "Waiting for client");
+ 	try (ServerSocket serverSocket = new ServerSocket(port);) {
+ 	    isRunning = true;
+ 	    // create a lobby on start
+ 	    Room.setServer(this);
+ 	    lobby = new Room(LOBBY);// , this);
+ 	    rooms.add(lobby);
+ 	    /*
+ 	    if (headless.equals("n")) { //initialize UI if called in CLI
+ 	    	setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+	 	   	windowSize.width *= .4;
+			windowSize.height *= .4;
+			setPreferredSize(windowSize);
+			setSize(windowSize);
+			setLocationRelativeTo(null);
+	
+			setTitle("Server");
+			card = new CardLayout();
+			setLayout(card);
+			createPanelHome();
+			createClientList();
+			showUI();
+ 	    }  	  */
+ 	    while (SocketServer.isRunning) {
+ 		try {
+ 		    Socket client = serverSocket.accept();
+ 		    log.log(Level.INFO, "Client connecting...");
+ 		    // Server thread is the server's representation of the client
+ 		    ServerThread thread = new ServerThread(client, lobby);
+ 		    thread.start();
+ 		    // create a dummy room until we get further client details
+ 		    // technically once a user fully joins this lobby will be destroyed
+ 		    // but we'll track it in an array so we can attempt to clean it up just in case
+ 		    Room prelobby = new Room(PRELOBBY);// , this);
+ 		    prelobby.addClient(thread);
+ 		    isolatedPrelobbies.add(prelobby);
+
+ 		    log.log(Level.INFO, "Client added to clients pool");
+ 		}
+ 		catch (IOException e) {
+ 		    e.printStackTrace();
+ 		}
+ 	    }
+
+ 	}
+ 	catch (IOException e) {
+ 	    e.printStackTrace();
+ 	}
+ 	finally {
+ 	    try {
+ 		isRunning = false;
+ 		cleanup();
+ 		log.log(Level.INFO, "closing server socket");
+ 	    }
+ 	    catch (Exception e) {
+ 		e.printStackTrace();
+ 	    }
+ 	}
+     }
+
+     protected void cleanupRoom(Room r) {
+ 	Iterator<Room> iter = isolatedPrelobbies.iterator();
+ 	while (iter.hasNext()) {
+ 	    Room check = iter.next();
+ 	    if (check.equals(r)) {
+ 		iter.remove();
+ 		log.log(Level.INFO, "Removed " + check.getName() + " from prelobbies");
+ 		break;
+ 	    }
+ 	}
+     }
+
+    private void cleanup() {
+	 	Iterator<Room> iter = this.rooms.iterator();
+	 	while (iter.hasNext()) {
+	 	    Room r = iter.next();
+	 	    try {
+	 		r.close();
+	 		iter.remove();
+	 	    }
+	 	    catch (Exception e) {
+	 		// it's ok to ignore this one
+	 	    }
+	 	}
+	 	Iterator<Room> pl = isolatedPrelobbies.iterator();
+	 	while (pl.hasNext()) {
+	 	    Room r = pl.next();
+	 	    try {
+	 		r.close();
+	 		pl.remove();
+	 	    }
+	 	    catch (Exception e) {
+	 		// it's ok to ignore this one
+	 	    }
+	 	}
+	 	try {
+	 	    lobby.close();
+	 	    log.log(Level.WARNING, "Lobby closed");
+	 	}
+	 	catch (Exception e) {
+	 	    // ok to ignore this too
+	 	}
+	     }
+	
+	     protected Room getLobby() {
+	 	return lobby;
+    }
+
+     protected List<String> getRooms(String room) {
+	 	// not the most efficient way to do it, but it works
+	 	List<String> roomNames = new ArrayList<String>();
+	 	Iterator<Room> iter = rooms.iterator();
+	 	// part 2, limit returned rooms
+	 	int i = 0;
+	 	int max = 10;// lets get up to 10 rooms
+	 	while (iter.hasNext()) {
+	 	    Room r = iter.next();
+	 	    // Part 2 added room name filter for searches
+	 	    if ((r != null && r.getName() != null)
+	 		    && (room == null || (room != null && r.getName().toLowerCase().contains(room.toLowerCase())))) {
+	 		roomNames.add(r.getName());
+	 	    }
+	
+	 	    i++;
+	 	    if (i > max) {
+	 		break;
+	 	    }
+	
+	 	}
+	 	return roomNames;
+     }
+
+     /***
+      * Special helper to join the lobby and close the previous room client was in if
+      * it's marked as Prelobby. Mostly used for prelobby once the server receives
+      * more client details.
+      * 
+      * @param client
+      */
+    protected void joinLobby(ServerThread client) {
+ 	Room prelobby = client.getCurrentRoom();
+ 	if (joinRoom(LOBBY, client)) {
+ 	    if (prelobby != null) {
+ 		prelobby.removeClient(client);
+ 		log.log(Level.INFO, "Added " + client.getClientName() + " to Lobby; Prelobby should self destruct");
+ 	    }
+ 	    else {
+ 		log.log(Level.WARNING, "Prelobby was null for " + client.getClientName());
+ 	    }
+ 	}
+ 	else {
+ 	    log.log(Level.INFO, "Problem moving " + client.getClientName() + " to lobby");
+ 	}
+ 	client.loadMuteList();
+    }
+
+     /***
+      * Helper function to check if room exists by case insensitive name
+      * 
+      * @param roomName The name of the room to look for
+      * @return matched Room or null if not found
+      */
+     private Room getRoom(String roomName) {
+ 	Iterator<Room> iter = rooms.iterator();
+ 	while (iter.hasNext()) {
+ 	    Room r = iter.next();
+ 	    if (r != null && r.getName() != null && r.getName().equalsIgnoreCase(roomName)) {
+ 		return r;
+ 	    }
+ 	}
+ 	/*
+ 	 * for (int i = 0, l = rooms.size(); i < l; i++) { Room r = rooms.get(i); if (r
+ 	 * == null || r.getName() == null) { continue; } if
+ 	 * (r.getName().equalsIgnoreCase(roomName)) { return r; } }
+ 	 */
+ 	log.log(Level.WARNING, "Error getting room " + roomName);
+ 	return null;
+     }
+
+     /***
+      * Attempts to join a room by name. Will remove client from old room and add
+      * them to the new room.
+      * 
+      * @param roomName The desired room to join
+      * @param client   The client moving rooms
+      * @return true if reassign worked; false if new room doesn't exist
+      */
+     protected synchronized boolean joinRoom(String roomName, ServerThread client) {
+	 	if (roomName == null || roomName.equalsIgnoreCase(PRELOBBY)) {
+	 	    log.log(Level.WARNING, "Room is either null or " + PRELOBBY);
+	 	    return false;
+	 	}
+	 	Room newRoom = getRoom(roomName);
+	 	Room oldRoom = client.getCurrentRoom();
+	 	if (newRoom != null) {
+	 	    if (oldRoom != null) {
+	 		log.log(Level.INFO, client.getClientName() + " leaving room " + oldRoom.getName());
+	 		oldRoom.removeClient(client);
+	 	    }
+	 	    else {
+	 		log.log(Level.WARNING, "old room is null for " + client.getClientName());
+	 	    }
+	 	    log.log(Level.INFO, client.getClientName() + " joining room " + newRoom.getName());
+	 	    newRoom.addClient(client);
+	 	    return true;
+	 	}
+	 	return false;
+     }
+
+     /***
+      * Attempts to create a room with given name if it doesn't exist already.
+      * 
+      * @param roomName The desired room to create
+      * @return true if it was created and false if it exists
+      */
+     protected synchronized boolean createNewRoom(String roomName) {
+	 	if (roomName == null || roomName.equalsIgnoreCase(PRELOBBY)) {
+	 	    return false;
+	 	}
+	 	if (getRoom(roomName) != null) {
+	 	    // TODO can't create room
+	 	    log.log(Level.INFO, "Room already exists");
+	 	    return false;
+	 	}
+	 	else {
+	 	    Room room = new Room(roomName);// , this);
+	 	    rooms.add(room);
+	 	    log.log(Level.INFO, "Created new room: " + roomName);
+	 	    return true;
+	 	}
+     }
+
+     public static void main(String[] args) {
+	 	// let's allow port to be passed as a command line arg
+	 	// in eclipse you can set this via "Run Configurations"
+	 	// -> "Arguments" -> type the port in the text box -> Apply
+	 	int port = -1;
+	 	try {
+	 	    port = Integer.parseInt(args[0]);
+	 	}
+	 	catch (Exception e) {
+	 	    // ignore this, we know it was a parsing issue
+	 	}
+	 	if (port > -1) {
+	 		Scanner scan = new Scanner(System.in); 
+	 		
+	 		// ask if you wish to run the server with UI or not
+	 		System.out.println("Run headless? (y/n)");
+	 		run = scan.nextLine();
+	 		scan.close();
+	 		
+	 		log.log(Level.INFO, "Starting Server");
+	 	 	SocketServer server = new SocketServer();
+	 	 	log.log(Level.INFO, "Listening on port " + port);
+	 	 	server.start(port, run);
+	 	 	log.log(Level.INFO, "Server Stopped");
+	 		
+	 				
+	 	}
+    }
+
+
+ }

--- a/Milestone4/User.java
+++ b/Milestone4/User.java
@@ -1,0 +1,37 @@
+package client;
+
+import javax.swing.JEditorPane;
+import javax.swing.JPanel;
+
+public class User extends JPanel {
+    /**
+	 * 
+	 */
+	private static final long serialVersionUID = 1L;
+	private String name;
+    private JEditorPane nameField;
+
+    public User(String name, String wrapper) {
+    	this.name = name;
+    	nameField = new JEditorPane();
+     	nameField.setContentType("text/html");
+     	//nameField.setText("<b>" + name + "</b>");
+     	nameField.setText(String.format(wrapper, name));
+     	nameField.setEditable(false);
+     	this.add(nameField);
+    }
+
+    public String getName() {
+	return name;
+    }
+    
+    public String getName(String wrapper) {
+    	return String.format(wrapper, name);
+    }
+    
+	public void setName(String name, String wrapper) {
+		//this.name = name;
+		// TODO Auto-generated method stub
+		nameField.setText(String.format(wrapper, name));
+	}
+}


### PR DESCRIPTION
<img width="707" alt="Screen Shot 2020-12-18 at 11 47 37 PM" src="https://user-images.githubusercontent.com/70597132/102706280-6f80c080-425e-11eb-8ffa-4cad678b0203.png">

Clicking the “export chat button” by the bottom of the frame allows the user to export their entire chat room history to “chat.txt.”

<img width="1162" alt="Screen Shot 2020-12-18 at 11 56 09 PM" src="https://user-images.githubusercontent.com/70597132/102706297-8fb07f80-425e-11eb-99b6-c384d5bbc0a0.png">

Client’s mute list will persist across sessions based on username match.
- ex. Client 2222 left then rejoined the chatroom without client 1111 unmuting them. Upon rejoining, client 2222 was still muted before client 1111 unmuted them. 

<img width="1149" alt="Screen Shot 2020-12-18 at 11 49 55 PM" src="https://user-images.githubusercontent.com/70597132/102706306-b4a4f280-425e-11eb-90a0-b8dbd6dfabc3.png">

Muted/unmuted clients get  notified by the server that another client muted/unmuted them. 

<img width="416" alt="Screen Shot 2020-12-20 at 12 26 13 AM" src="https://user-images.githubusercontent.com/70597132/102706318-d30aee00-425e-11eb-819e-a06483e40e89.png">

IsMuted() method makes sure that only previously unmuted clients can receive a muted message, and vice versa. 

<img width="982" alt="Screen Shot 2020-12-18 at 11 41 19 PM" src="https://user-images.githubusercontent.com/70597132/102706332-f33aad00-425e-11eb-9fd8-41905beb4104.png">

Upon mute of a user, their name should be crossed out in the user list (unmuting them returns their name to normal). However, there are rare exceptions when that client's name actually disappears completely after they get muted, and will not reappear. I am assuming that has something to do with the formatting of the JEditorPane itself (possibly changing the font/style of the text affected it’s size so that it was not properly displayed by the JEditorPane again, or maybe it messed with the visibility of the JEditorPane itself).

<img width="1187" alt="Screen Shot 2020-12-18 at 11 43 38 PM" src="https://user-images.githubusercontent.com/70597132/102706350-182f2000-425f-11eb-8d10-52d1bb548c91.png">

The last person to send a message to the client gets their name bolded in the userlist. However, a similar problem appears here as a name will sometimes disappear. I assume that the problem here is the same as in the one above.


HONORS SERVER UI

<img width="575" alt="Screen Shot 2020-12-19 at 12 35 30 AM" src="https://user-images.githubusercontent.com/70597132/102706369-4f053600-425f-11eb-97bf-16cab72e8277.png">

Server will be able to run with a UI and show connected clients.
UI has a client list to the right of the JFrame, each with their own “disconnect” button if the server wishes to disconnect them. 

<img width="1151" alt="Screen Shot 2020-12-19 at 12 37 51 AM" src="https://user-images.githubusercontent.com/70597132/102706401-aa372880-425f-11eb-9cfe-29245e46ae3c.png">

Upon clicking the “disconnect” button under a client they will be disconnected by the server. The server notifies them with an announcement.

<img width="574" alt="Screen Shot 2020-12-19 at 12 33 50 AM" src="https://user-images.githubusercontent.com/70597132/102706426-cc30ab00-425f-11eb-8c1b-043a4ba1c9e8.png">

<img width="1151" alt="Screen Shot 2020-12-19 at 12 37 51 AM" src="https://user-images.githubusercontent.com/70597132/102706401-aa372880-425f-11eb-9cfe-29245e46ae3c.png">

UI shows server uptime (amount of time JVM has been running) and memory usage (JVM total memory minus JVM free memory which gets the memory used since the application started) on server start (both numbers should be close to 0). Upon clicking the refresh button, both these statistics refresh and return the uptime and memory use when the button was clicked. 

<img width="574" alt="Screen Shot 2020-12-19 at 12 33 50 AM" src="https://user-images.githubusercontent.com/70597132/102706441-f2564b00-425f-11eb-92d3-16eb7b2f13a1.png">

<img width="486" alt="Screen Shot 2020-12-20 at 12 24 10 AM" src="https://user-images.githubusercontent.com/70597132/102706449-fb471c80-425f-11eb-9944-4e579bd964de.png">

<img width="367" alt="Screen Shot 2020-12-20 at 12 20 32 AM" src="https://user-images.githubusercontent.com/70597132/102706453-000bd080-4260-11eb-9375-664967e59544.png">

Clicking the “close server” button calls the SocketServer cleanup() method and exits the program after changing the server's isRunning boolean to false. 

<img width="369" alt="Screen Shot 2020-12-19 at 12 48 53 AM" src="https://user-images.githubusercontent.com/70597132/102706480-46f9c600-4260-11eb-8e4f-67186fb82e32.png">

<img width="370" alt="Screen Shot 2020-12-19 at 12 49 43 AM" src="https://user-images.githubusercontent.com/70597132/102706482-4b25e380-4260-11eb-9125-4a9be684666d.png">

Command line asks if you wish to run headless; entering “n” starts the serverUI, entering any other string/value does not start the UI and runs it headless.
